### PR TITLE
Implement fullscreen toggle

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -42,6 +42,7 @@
   "viewer_toggle_mode_tooltip": "Toggle view mode",
   "viewer_search_tooltip": "Search (Ctrl+F)",
   "viewer_fullscreen_tooltip": "Fullscreen",
+  "viewer_exit_fullscreen_tooltip": "Exit fullscreen",
   "delimiters_settings_label": "Delimiter settings:",
   "delimiter_start_label": "Start:",
   "delimiter_end_label": "End:",

--- a/locales/ro.json
+++ b/locales/ro.json
@@ -42,6 +42,7 @@
   "viewer_toggle_mode_tooltip": "Comutați modul de vizualizare",
   "viewer_search_tooltip": "Căutare (Ctrl+F)",
   "viewer_fullscreen_tooltip": "Ecran complet",
+  "viewer_exit_fullscreen_tooltip": "Ieșire ecran complet",
   "delimiters_settings_label": "Setări delimitatori:",
   "delimiter_start_label": "Început:",
   "delimiter_end_label": "Sfârșit:",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -43,6 +43,7 @@
   "viewer_toggle_mode_tooltip": "Переключить режим просмотра",
   "viewer_search_tooltip": "Поиск (Ctrl+F)",
   "viewer_fullscreen_tooltip": "Во весь экран",
+  "viewer_exit_fullscreen_tooltip": "Выйти из полноэкранного режима",
   "delimiters_settings_label": "Настройки разделителей:",
   "delimiter_start_label": "Начало:",
   "delimiter_end_label": "Конец:",

--- a/main.js
+++ b/main.js
@@ -397,6 +397,15 @@ function initializeApp(store) {
     clipboard.writeText(text);
   });
 
+  ipcMain.handle('window:toggle-fullscreen', () => {
+    if (mainWindow) {
+      const isFull = mainWindow.isFullScreen();
+      mainWindow.setFullScreen(!isFull);
+      return !isFull;
+    }
+    return false;
+  });
+
   ipcMain.on('app:quit', () => {
     app.quit();
   });

--- a/preload.js
+++ b/preload.js
@@ -32,7 +32,8 @@ contextBridge.exposeInMainWorld('api', {
   onPathsSelected: (callback) => ipcRenderer.on('paths-selected', (_, paths) => callback(paths)),
   onTriggerSave: (callback) => ipcRenderer.on('trigger-save', callback),
   onTriggerOpen: (callback) => ipcRenderer.on('trigger-open', callback),
-  
+
   // Управление приложением
-  quitApp: () => ipcRenderer.send('app:quit')
+  quitApp: () => ipcRenderer.send('app:quit'),
+  toggleFullScreen: () => ipcRenderer.invoke('window:toggle-fullscreen')
 });

--- a/renderer/viewer.js
+++ b/renderer/viewer.js
@@ -49,7 +49,8 @@ const CodeViewer = {
     theme: 'dark',
     searchAll: false,
     searchPanelOpen: false,
-    searchQuery: ''
+    searchQuery: '',
+    isFullscreen: false
   },
 
   onFileDroppedOrSelected: null,
@@ -73,6 +74,7 @@ const CodeViewer = {
 
     this.onFileDroppedOrSelected = options.onFileDroppedOrSelected;
     this.addEventListeners();
+    this.updateFullscreenButton(false);
     console.log('CodeViewer initialized!');
   },
 
@@ -93,9 +95,10 @@ const CodeViewer = {
     this.elements.nextBtn.addEventListener('click', () => this.nextFile());
     this.elements.toggleModeBtn.addEventListener('click', () => this.toggleViewMode());
     this.elements.searchBtn.addEventListener('click', () => this.openSearch());
-    this.elements.fullscreenBtn.addEventListener('click', () => {
-    showToast('Полноэкранный режим будет добавлен в будущих версиях!', 'info');
-});
+    this.elements.fullscreenBtn.addEventListener('click', async () => {
+      const isFull = await window.api.toggleFullScreen();
+      this.updateFullscreenButton(isFull);
+    });
     // Сохраняем позицию скролла при прокрутке в режиме одного файла
     this.elements.content.addEventListener('scroll', () => {
         if (this.state.viewMode === 'single' && this.state.currentFileIndex !== -1) {
@@ -443,6 +446,13 @@ showFile(index) {
     document.body.classList.toggle('dark-theme', theme === 'dark');
   },
 
+  updateFullscreenButton(isFull) {
+    this.state.isFullscreen = isFull;
+    const tooltipKey = isFull ? 'viewer_exit_fullscreen_tooltip' : 'viewer_fullscreen_tooltip';
+    this.elements.fullscreenBtn.title = this.t(tooltipKey);
+    this.elements.fullscreenBtn.textContent = isFull ? '🗗' : '⛶';
+  },
+
   updateUiForLanguage(t) {
     if (!t || !this.elements.container) return; // Защита от ошибок
     this.t = t;
@@ -451,7 +461,8 @@ showFile(index) {
     this.elements.nextBtn.title = t('viewer_next_file_tooltip');
     this.elements.toggleModeBtn.title = t('viewer_toggle_mode_tooltip');
     this.elements.searchBtn.title = t('viewer_search_tooltip');
-    this.elements.fullscreenBtn.title = t('viewer_fullscreen_tooltip');
+    const fsKey = this.state.isFullscreen ? 'viewer_exit_fullscreen_tooltip' : 'viewer_fullscreen_tooltip';
+    this.elements.fullscreenBtn.title = t(fsKey);
   },
 
   setPhrases(newPhrases) {


### PR DESCRIPTION
## Summary
- add IPC handler and preload bridge for toggling fullscreen
- implement fullscreen state management in viewer
- change fullscreen button behavior and translations

## Testing
- `npm install`
- `npm start` *(fails: libatk-1.0.so.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ff41307c83258a589b810187a64b