### PR TITLE
Add .gitignore with common patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Node dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+out/
+
+# Logs
+*.log
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Environment files
+.env
+
+# Additional common ignores
+coverage/
+


### PR DESCRIPTION
## Summary
- add standard `.gitignore` for node/electron project

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688929da5980832589ce2034d13b5111