### PR TITLE
Fix search panel selector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,9 @@ Recent work added a .gitignore, improved localization strings, and implemented a
 CodeMirror viewer with navigation and search. The fullscreen button now expands
 only the code viewer with a smooth 0.2s animation and can be toggled via the
 Alt+Enter hotkey. The Escape key now closes the search panel before exiting
-fullscreen.
+fullscreen. Search panel logic now queries the dedicated `viewer-search-container`
+for `.cm-search` elements so the extra checkbox and navigation buttons work
+reliably.
 
 ## Planned Work
 

--- a/renderer/viewer.js
+++ b/renderer/viewer.js
@@ -419,7 +419,8 @@ showFile(index) {
   },
 
   patchSearchPanel(view) {
-    const panel = view.dom.querySelector('.cm-search');
+    let panel = searchPanelContainer.querySelector('.cm-search');
+    if (!panel) panel = view.dom.querySelector('.cm-search');
     if (!panel) return;
     if (!panel.dataset.extraAdded) {
       const label = document.createElement('label');
@@ -484,7 +485,8 @@ showFile(index) {
 
   searchStep(forward, view) {
     if (!view) return;
-    const panel = view.dom.querySelector('.cm-search');
+    let panel = searchPanelContainer.querySelector('.cm-search');
+    if (!panel) panel = view.dom.querySelector('.cm-search');
     if (!panel) return;
     const input = panel.querySelector('[main-field]');
     const query = (input ? input.value : this.state.searchQuery) || '';


### PR DESCRIPTION
## Summary
- patchSearchPanel/searchStep now look for search panel in #viewer-search-container
- document change in AGENTS.md

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c7548430883258e9a56e8922afea2